### PR TITLE
Active crown fire development

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -534,11 +534,12 @@ contains
     currentCohort%ddbhdt             = nan ! time derivative of dbh 
 
     ! FIRE
-    currentCohort%fraction_crown_burned  = nan ! proportion of crown affected by fire
-    currentCohort%passive_crown_fire_flg = nan ! flag to indicate passive crown fire ignition
-    currentCohort%cambial_mort           = nan ! probability that trees dies due to cambial char P&R (1986)
-    currentCohort%crownfire_mort         = nan ! probability of tree post-fire mortality due to crown scorch
-    currentCohort%fire_mort              = nan ! post-fire mortality from cambial and crown damage assuming two are independent
+    currentCohort%fraction_crown_burned = nan ! proportion of crown affected by fire
+    currentCohort%passive_crown_fire_flg = 9999 ! flag to indicate passive crown fire ignition
+    currentCohort%active_crown_fire_flg = 9999 ! flag to indicate active crown fire ignition
+    currentCohort%cambial_mort          = nan ! probability that trees dies due to cambial char P&R (1986)
+    currentCohort%crownfire_mort        = nan ! probability of tree post-fire mortality due to crown scorch
+    currentCohort%fire_mort             = nan ! post-fire mortality from cambial and crown damage assuming two are independent
 
   end subroutine nan_cohort
 
@@ -580,7 +581,8 @@ contains
 
     currentcohort%year_net_uptake(:) = 999._r8 ! this needs to be 999, or trimming of new cohorts will break. 
     currentcohort%ts_net_uptake(:)   = 0._r8
-    currentCohort%size_class         = 1
+    currentcohort%fraction_crown_burned = 0._r8 
+    currentCohort%size_class            = 1
     currentCohort%seed_prod          = 0._r8
     currentCohort%size_class_lasttimestep = 0
     currentcohort%npp_acc_hold       = 0._r8 

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -971,7 +971,7 @@ contains
                          currentCohort%crown_fire_flg = 1  ! passive crown fire ignited
                          currentCohort%fraction_crown_burned =  1.0_r8
                          ! Initiation of active crown fire, EQ 14b Bessie and Johnson 1995
-                         ignite_active_crown = currentPatch%FI/currentCohort%active_crown_FI
+                         ignite_active_crown = currentPatch%FI/active_crown_FI
                          if (ignite_active_crown >= 1.0_r8) then
                             ! In code design phase; see
                             ! https://github.com/NGEET/fates/issues/573

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -933,7 +933,7 @@ contains
 
                 
                 ! Evaluate for passive crown fire ignition
-                if (EDPftvarcon_inst%crown_fire(currentCohort%pft) == 1) then
+                if (EDPftvarcon_inst%crown_fire(currentCohort%pft) > 0.001_r8) then
                    
                    ! Note: crown_ignition_energy to be calculated based on foliar moisture content from FATES-Hydro
                    ! EQ 3 Van Wagner 1977
@@ -961,7 +961,7 @@ contains
                       
                       if (ignite_crown >= 1.0_r8) then
                          currentCohort%passive_crown_fire_flg = 1 ! passive crown fire ignited
-                         currentCohort%fraction_crown_burned =  1.0_r8
+                         currentCohort%fraction_crown_burned = EDPftvarcon_inst%crown_fire(currentCohort%pft)
                          ! Initiation of active crown fire, EQ 14b Bessie and Johnson 1995
                          ignite_active_crown = currentPatch%FI/active_crown_FI
                          if (ignite_active_crown >= 1.0_r8) then

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -113,7 +113,7 @@ contains
    !*****************************************************************
    ! currentSite%acc_NI is the accumulated Nesterov fire danger index
 
-    use SFParamsMod,        only : SF_val_fdi_a, SF_val_fdi_b
+    use SFParamsMod, only  : SF_val_fdi_a, SF_val_fdi_b
     use FatesConstantsMod , only : tfrz => t_water_freeze_k_1atm
     use FatesConstantsMod , only : sec_per_day
 
@@ -166,7 +166,7 @@ contains
 
     type(ed_patch_type),  pointer :: currentPatch
     type(ed_cohort_type), pointer :: currentCohort
-    type(litter_type),    pointer :: litt_c
+    type(litter_type), pointer    :: litt_c
 
     real(r8) alpha_FMC(nfsc)     ! Relative fuel moisture adjusted per drying ratio
     real(r8) fuel_moisture(nfsc) ! Scaled moisture content of small litter fuels. 
@@ -438,8 +438,8 @@ contains
     real(r8) a_beta               ! dummy variable for product of a* beta_ratio for react_v_opt equation
     real(r8) a,b,c,e              ! function of fuel sav
 
-    logical,parameter  :: debug_windspeed = .false.  !for debugging
-    real(r8),parameter :: q_dry           = 581.0_r8 !heat of pre-ignition of dry fuels (kJ/kg)
+    logical,parameter :: debug_windspeed = .false. !for debugging
+    real(r8),parameter :: q_dry = 581.0_r8 !heat of pre-ignition of dry fuels (kJ/kg)
 
     currentPatch=>currentSite%oldest_patch;  
 
@@ -572,8 +572,8 @@ contains
     !returns the  the hypothetic fuel consumed by the fire
 
     use SFParamsMod, only : SF_val_miner_total, SF_val_min_moisture, &
-                            SF_val_mid_moisture, SF_val_low_moisture_Coeff, SF_val_low_moisture_Slope, &
-                            SF_val_mid_moisture_Coeff, SF_val_mid_moisture_Slope
+         SF_val_mid_moisture, SF_val_low_moisture_Coeff, SF_val_low_moisture_Slope, &
+         SF_val_mid_moisture_Coeff, SF_val_mid_moisture_Slope
 
     type(ed_site_type) , intent(in), target :: currentSite
     type(ed_patch_type), pointer    :: currentPatch
@@ -662,8 +662,8 @@ contains
     !currentPatch%TFC_ROS total fuel consumed by flaming front (kgC/m2)
 
     use FatesInterfaceMod, only : hlm_use_spitfire
-    use SFParamsMod,       only : SF_val_fdi_alpha,SF_val_fuel_energy, &
-                                  SF_val_max_durat, SF_val_durat_slope
+    use SFParamsMod,  only : SF_val_fdi_alpha,SF_val_fuel_energy, &
+         SF_val_max_durat, SF_val_durat_slope
 
     type(ed_site_type), intent(inout), target :: currentSite
 
@@ -687,11 +687,11 @@ contains
        !'decide_fire' subroutine shortened and put in here... 
        if (currentPatch%FI >= fire_threshold) then  ! 50kW/m is the threshold for a self-sustaining fire
           currentPatch%fire = 1 ! Fire...    :D
-          
+
           ! Equation 7 from Venevsky et al GCB 2002 (modification of equation 8 in Thonicke et al. 2010) 
           ! FDI 0.1 = low, 0.3 moderate, 0.75 high, and 1 = extreme ignition potential for alpha 0.000337
           currentSite%FDI  = 1.0_r8 - exp(-SF_val_fdi_alpha*currentSite%acc_NI)
-          
+
           ! Equation 14 in Thonicke et al. 2010
           ! fire duration in minutes
 
@@ -705,7 +705,7 @@ contains
           !currentPatch%FD = 60.0_r8 * 24.0_r8 !no minutes in a day      
        else     
           currentPatch%fire = 0 ! No fire... :-/
-          currentPatch%FD   = 0.0_r8      
+          currentPatch%FD   = 0.0_r8
        endif
        !  FIX(SPM,032414) needs a refactor
        !  FIX(RF,032414) : should happen outside of SF loop - doing all spitfire code is inefficient otherwise. 
@@ -736,7 +736,6 @@ contains
     real(r8) AB               !daily area burnt in m2 per km2
     real(r8) size_of_fire !in m2
     real(r8),parameter :: km2_to_m2 = 1000000.0_r8 !area conversion for square km to square m 
-    integer g, p
 
     !  ---initialize site parameters to zero--- 
     currentSite%frac_burnt = 0.0_r8   
@@ -775,7 +774,7 @@ contains
 
           ! --- calculate area burnt---
           if(lb > 0.0_r8) then
-     
+
              ! Equation 1 in Thonicke et al. 2010
              ! To Do: Connect here with the Li & Levis GDP fire suppression algorithm. 
              ! Equation 16 in arora and boer model JGR 2005
@@ -814,7 +813,7 @@ contains
 
     type(ed_site_type), intent(in), target :: currentSite
 
-    type(ed_patch_type),  pointer :: currentPatch
+    type(ed_patch_type), pointer :: currentPatch
     type(ed_cohort_type), pointer :: currentCohort
 
     real(r8) ::  f_ag_bmass      ! fraction of tree cohort's above-ground biomass as a proportion of total patch ag tree biomass
@@ -888,7 +887,7 @@ contains
 
     !returns the updated currentCohort%fraction_crown_burned for each tree cohort within each patch.
     !currentCohort%fraction_crown_burned is the proportion of crown affected by fire
-    
+
 
 
     type(ed_site_type), intent(in), target :: currentSite
@@ -917,7 +916,6 @@ contains
           do while(associated(currentCohort))  
              currentCohort%fraction_crown_burned = 0.0_r8
 
-             
              if (EDPftvarcon_inst%woody(currentCohort%pft) == 1) then !trees only
                 
                 ! height_cbb = clear branch bole height at base of crown (m)
@@ -1027,7 +1025,7 @@ contains
        if (currentPatch%fire == 1) then
           currentCohort => currentPatch%tallest;
           do while(associated(currentCohort))
-             !currentCohort%cambial_mort = 0.0_r8 !testing this removal
+             currentCohort%cambial_mort = 0.0_r8
              if (EDPftvarcon_inst%woody(currentCohort%pft) == 1) then !trees only
                 ! Equation 21 in Thonicke et al 2010
                 bt = EDPftvarcon_inst%bark_scaler(currentCohort%pft)*currentCohort%dbh ! bark thickness. 
@@ -1084,7 +1082,7 @@ contains
                 ! Equation 22 in Thonicke et al. 2010. 
                 currentCohort%crownfire_mort = EDPftvarcon_inst%crown_kill(currentCohort%pft)*currentCohort%fraction_crown_burned**3.0_r8
                 ! Equation 18 in Thonicke et al. 2010. 
-                currentCohort%fire_mort = max(0.0_r8,min(1.0_r8,currentCohort%crownfire_mort+currentCohort%cambial_mort- &
+                currentCohort%fire_mort = max(0._r8,min(1.0_r8,currentCohort%crownfire_mort+currentCohort%cambial_mort- &
                      (currentCohort%crownfire_mort*currentCohort%cambial_mort)))  !joint prob.   
              else
                 currentCohort%fire_mort = 0.0_r8 !Set to zero. Grass mode of death is removal of leaves.

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -344,8 +344,8 @@ module EDTypesMod
 
      ! FIRE
      real(r8) ::  fraction_crown_burned                  ! proportion of crown affected by fire:-
-     real(r8) ::  active_crown_fire_flg                  ! flag for active crown fire ignition
-     real(r8) ::  passive_crown_fire_flg                 ! flag for passive crown fire ignition (1=ignition)
+     integer ::  active_crown_fire_flg                   ! flag for active crown fire ignition
+     integer ::  passive_crown_fire_flg                  ! flag for passive crown fire ignition (1=ignition)
      real(r8) ::  cambial_mort                           ! probability that trees dies due to cambial char 
                                                          ! (conditional on the tree being subjected to the fire)
      real(r8) ::  crownfire_mort                         ! probability of tree post-fire mortality 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -4540,12 +4540,12 @@ end subroutine flush_hvars
           upfreq=1, ivar=ivar, initialize=initialize_variables, index = ih_m5_si_scpf )
 
     call this%set_history_var(vname='CROWNFIREMORT_SCPF', units = 'N/ha/yr',          &
-          long='crown fire mortality by pft/size',use_default='inactive', &
+          long='crown fire mortality by pft/size',use_default='active', &
           avgflag='A', vtype=site_size_pft_r8, hlms='CLM:ALM', flushval=0.0_r8,    &
           upfreq=1, ivar=ivar, initialize=initialize_variables, index = ih_crownfiremort_si_scpf )
 
     call this%set_history_var(vname='CAMBIALFIREMORT_SCPF', units = 'N/ha/yr',          &
-          long='cambial fire mortality by pft/size',use_default='inactive', &
+          long='cambial fire mortality by pft/size',use_default='active', &
           avgflag='A', vtype=site_size_pft_r8, hlms='CLM:ALM', flushval=0.0_r8,    &
           upfreq=1, ivar=ivar, initialize=initialize_variables, index = ih_cambialfiremort_si_scpf )
 


### PR DESCRIPTION
Following @jkshuman's introduction of the Bessie and Johnson (1995)
formulation for determining the presence of passive crown fire (https://github.com/NGEET/fates/pull/572), I now add the same paper's formulation for determining the presence of active crown fire.

### Description:
All changes are in subroutine crown_damage:
Where @jkshuman introduced Eq. 8 from Bessie and Johnson (1995) I also introduced Eq. 12.
Where @jkshuman introduced Eq. 14a from Bessie and Johnson (1995) I also introduced Eq. 14b.

These equations determine whether passive/active crown fire will occur. As of 9/6/2019, I have not included the effects of active crown fire, which is a topic of discussion for now.

Discussion here:
https://github.com/NGEET/fates/issues/573

### Collaborators:
@jkshuman @lmkueppers @pollybuotte @rgknox @rosiealice @xuchongang @ckoven

### Expectation of Answer Changes:
Answers will change once we include the effect of active crown fires, not just their presence.

### Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:
